### PR TITLE
Fix luck window for cyberpunkred

### DIFF
--- a/rulesets/cyberpunkred_compilation.xml
+++ b/rulesets/cyberpunkred_compilation.xml
@@ -671,4 +671,8 @@
 		</buttongroup_tabs>
 	</sheetdata>
   </windowclass>
+
+  <windowclass name="charsheet_applyLuck" merge="join">
+	<frame>recordsheet</frame>
+  </windowclass>
 </root>


### PR DESCRIPTION
This fixes the apply luck window on cyberpunk red to override the frame to use recordsheet instead.